### PR TITLE
wording

### DIFF
--- a/etc/qubes/yk-keys/yk-vm
+++ b/etc/qubes/yk-keys/yk-vm
@@ -1,5 +1,5 @@
 # The name of the Qubes VM where the YK is inserted.
-# Must have USB controller assigned, or USB passed.
+# Must have USB controller assigned, or YubiKey assigned.
 # Note: this VM is *not* considered trusted.
 
 sys-usb


### PR DESCRIPTION
`passed` is unclear. Elsewhere in Qubes documentation we (quite consistently) use the verb `assigned`. (Example: https://www.qubes-os.org/doc/assigning-devices/)

I doubt any USB can be assigned. I guess YubiKey must be assigned (if no USB controller is assigned).