### PR TITLE
fix quoting

### DIFF
--- a/bin/yk-auth
+++ b/bin/yk-auth
@@ -29,7 +29,7 @@ fi
 
 challenge=`head -c64 /dev/urandom | xxd -c 64 -ps`
 # You may need to adjust slot number and USB VM name here
-response=`qvm-run -a -u root --nogui -p $ykvm "ykchalresp -2 -x $challenge"`
+response=$(qvm-run -a -u root --nogui -p $ykvm "ykchalresp -2 -x '$challenge'")
 
 correct_response=`echo $challenge | xxd -r -ps | openssl dgst -sha1 -macopt hexkey:$key -mac HMAC -r | cut -f1 -d ' '`
 


### PR DESCRIPTION
I think we should use proper quotes there. Even if the input isn't expected to contain quotes that could break it at that stage, correct syntax should still be consistent everywhere.

```
[user@dom0 ~]$ test="a long \" test"

[user@dom0 ~]$ qvm-run --pass-io work "echo $test"
sh: 1: Syntax error: Unterminated quoted string

[user@dom0 ~]$ qvm-run --pass-io work "echo '$test'"
a long " test
```

In theory we could also `$ykvm` -> `"$ykvm"` but it's not that important. Someone could (ab)use it to inject whatever extra parameters.