### PR TITLE
reduce challenge length to 63 bytes

### DIFF
--- a/bin/yk-auth
+++ b/bin/yk-auth
@@ -27,7 +27,7 @@ if [ -n "$pass_hash" ]; then
     fi
 fi
 
-challenge=$(head -c64 /dev/urandom | xxd -c 64 -ps)
+challenge=$(head -c63 /dev/urandom | xxd -c 63 -ps)
 # You may need to adjust slot number here
 response=$(qvm-run -a -u root --nogui -p $ykvm "ykchalresp -2 -x '$challenge'")
 


### PR DESCRIPTION
The 64 byte length does not appear to work with a yubikey neo. I'm guessing a null terminator is being chopped off on the dongle, but is being used to generate the correct response. Reducing the challenge size by one byte fixes the issue.