### PR TITLE
Allow for HMAC-SHA1 configured for variable length

### DIFF
--- a/bin/yk-auth
+++ b/bin/yk-auth
@@ -27,7 +27,7 @@ if [ -n "$pass_hash" ]; then
     fi
 fi
 
-challenge=$(head -c64 /dev/urandom | xxd -c 64 -ps)
+challenge=$(head -c63 /dev/urandom | xxd -c 63 -ps)
 # You may need to adjust slot number here
 response=$(qvm-run -a -u root --nogui -p $ykvm "ykchalresp -2 -x '$challenge'")
 

--- a/bin/yk-auth
+++ b/bin/yk-auth
@@ -27,11 +27,14 @@ if [ -n "$pass_hash" ]; then
     fi
 fi
 
-challenge=$(head -c63 /dev/urandom | xxd -c 63 -ps)
+challenge=$(head -c64 /dev/urandom | xxd -c 64 -ps)
 # You may need to adjust slot number here
 response=$(qvm-run -a -u root --nogui -p $ykvm "ykchalresp -2 -x '$challenge'")
 
 correct_response=$(echo $challenge | xxd -r -ps | openssl dgst -sha1 -macopt hexkey:$key -mac HMAC -r | cut -f1 -d ' ')
+# A yubikey configured for a variable length challenge will truncate the last byte when given a 64 byte challenge
+# The 'correct' response for a yubikey in that configuration will be:
+alternate_response=$(echo $challenge | cut -c1-126 | xxd -r -ps | openssl dgst -sha1 -macopt hexkey:$key -mac HMAC -r | cut -f1 -d ' ')
 
-test "x$correct_response" = "x$response"
+test "x$correct_response" = "x$response" -o "x$alternate_response" = "x$response"
 exit $?


### PR DESCRIPTION
Sure it's not the correct configuration specified in the docs, but this allows a yubikey configured for variable length input to still work.