### PR TITLE
Read challenge-response slot from yk-slot

### DIFF
--- a/bin/yk-auth
+++ b/bin/yk-auth
@@ -17,6 +17,7 @@ if [ -z "$pass_hash" -a -r "$CONFIG_DIR/yk-login-pass" ]; then
     fi
 fi
 ykvm=$(cat $CONFIG_DIR/yk-vm | grep -v '^#' | tr -d '\n')
+ykslot=$(cat $CONFIG_DIR/yk-slot | grep -v '^#' | tr -d '\n')
 
 # if password was given, verify it
 if [ -n "$pass_hash" ]; then
@@ -28,8 +29,7 @@ if [ -n "$pass_hash" ]; then
 fi
 
 challenge=$(head -c64 /dev/urandom | xxd -c 64 -ps)
-# You may need to adjust slot number here
-response=$(qvm-run -a -u root --nogui -p $ykvm "ykchalresp -2 -x '$challenge'")
+response=$(qvm-run -a -u root --nogui -p $ykvm "ykchalresp -'$ykslot' -x '$challenge'")
 
 correct_response=$(echo $challenge | xxd -r -ps | openssl dgst -sha1 -macopt hexkey:$key -mac HMAC -r | cut -f1 -d ' ')
 # A yubikey configured for a variable length challenge will truncate the last byte when given a 64 byte challenge

--- a/etc/qubes/yk-keys/yk-slot
+++ b/etc/qubes/yk-keys/yk-slot
@@ -1,0 +1,2 @@
+# The YubiKey challenge-response slot.
+2

--- a/rpm_spec/qubes-yubikey-dom0.spec.in
+++ b/rpm_spec/qubes-yubikey-dom0.spec.in
@@ -27,6 +27,7 @@ cp -a bin $RPM_BUILD_ROOT/usr/
 %doc README.md
 %config(noreplace) /etc/pam.d/yubikey
 %config(noreplace) /etc/qubes/yk-keys/yk-vm
+%config(noreplace) /etc/qubes/yk-keys/yk-slot
 %config(noreplace) /etc/qubes/yk-keys/yk-login-pass
 %config(noreplace) /etc/qubes/yk-keys/yk-login-pass-hashed.hex
 %config(noreplace) /etc/qubes/yk-keys/yk-secret-key.hex


### PR DESCRIPTION
Hardcoding slot 2 in `yk-auth` means that users with their chalresp login on slot 1 have to be careful when upgrading dom0.  This commit reads the slot from `$CONFIG_DIR/yk-slot` instead.

On a bit of a tangent, but having one config file per user-configurable parameter is somewhat strange.  I wasn't sure whether to create a `yk-config` file and combine (at least) `yk-vm` and `yk-slot` in that file.